### PR TITLE
[Feat] api 통신 공통 함수

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,30 +5,30 @@ import type {
     DeleteApiParams,
     RequestParams,
     ApiResponse,
+    ApiPayload,
 } from '@/types/api'
 
-/* 사용법
+/** 사용법
 import { get, post, patch, del } from '@/lib/api'
 
-// ex) get
+ex) get
 const response = await get<타입>({ endpoint: 'url' })
 const todos = response.data
 
-// ex) post / patch
+ex) post / patch
 const response = await post<타입>({ 
     endpoint: 'url', 
     data: {  } 
 })
 const newTodo = response.data
 
-// ex) delete
+ex) delete
 const response = await del({ endpoint: 'url' })
 */
 
-// API Base URL 설정
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000/api'
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL
 
-// 통합된 HTTP 요청 함수
+/** 통합된 HTTP 요청 함수 */
 async function request<T>({method, endpoint, data, options}: RequestParams): Promise<ApiResponse<T>> {
     const url = `${API_BASE_URL}/${endpoint}`
     const response = await fetch(url, {
@@ -42,23 +42,23 @@ async function request<T>({method, endpoint, data, options}: RequestParams): Pro
     })
 
     const status = response.status
-    const payload = await response.json().catch(() => ({}))
+    const payload = (await response.json()) as Partial<ApiPayload<T>>;
 
     if (!response.ok) {
-        const message = (payload as any).message || `HTTP error! status: ${status}`
+        const message = payload.message || `HTTP error! status: ${status}`
         throw new Error(message)
     }
 
-    // data가 null or undefined 이면 status 반환
+    /** data가 null or undefined 이면 status 반환 */
     const apiResponse: ApiResponse<T> = {
-        data: (payload as any).data ?? (payload as T),
+        data: payload.data ?? (payload as unknown as T),
         status,
-        message: (payload as any).message,
+        message: payload.message,
     }
     return apiResponse
 }
 
-// HTTP 메서드별 함수
+/** HTTP 메서드별 함수 */
 export function get<T>({endpoint, options}: GetApiParams): Promise<ApiResponse<T>> {
     return request<T>({method: 'GET', endpoint, options})
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,76 @@
+import type {
+    GetApiParams,
+    PostApiParams,
+    PatchApiParams,
+    DeleteApiParams,
+    RequestParams,
+    ApiResponse,
+} from '@/types/api'
+
+/* 사용법
+import { get, post, patch, del } from '@/lib/api'
+
+// ex) get
+const response = await get<타입>({ endpoint: 'url' })
+const todos = response.data
+
+// ex) post / patch
+const response = await post<타입>({ 
+    endpoint: 'url', 
+    data: {  } 
+})
+const newTodo = response.data
+
+// ex) delete
+const response = await del({ endpoint: 'url' })
+*/
+
+// API Base URL 설정
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000/api'
+
+// 통합된 HTTP 요청 함수
+async function request<T>({method, endpoint, data, options}: RequestParams): Promise<ApiResponse<T>> {
+    const url = `${API_BASE_URL}/${endpoint}`
+    const response = await fetch(url, {
+        method,
+        headers: {
+            'Content-Type': 'application/json',
+            ...options?.headers,
+        },
+        body: data ? JSON.stringify(data) : undefined,
+        ...options,
+    })
+
+    const status = response.status
+    const payload = await response.json().catch(() => ({}))
+
+    if (!response.ok) {
+        const message = (payload as any).message || `HTTP error! status: ${status}`
+        throw new Error(message)
+    }
+
+    // data가 null or undefined 이면 status 반환
+    const apiResponse: ApiResponse<T> = {
+        data: (payload as any).data ?? (payload as T),
+        status,
+        message: (payload as any).message,
+    }
+    return apiResponse
+}
+
+// HTTP 메서드별 함수
+export function get<T>({endpoint, options}: GetApiParams): Promise<ApiResponse<T>> {
+    return request<T>({method: 'GET', endpoint, options})
+}
+
+export function post<T>({endpoint, data, options}: PostApiParams): Promise<ApiResponse<T>> {
+    return request<T>({method: 'POST', endpoint, data, options})
+}
+
+export function patch<T>({endpoint, data, options}: PatchApiParams): Promise<ApiResponse<T>> {
+    return request<T>({method: 'PATCH', endpoint, data, options})
+}
+
+export function del<T>({endpoint, options}: DeleteApiParams): Promise<ApiResponse<T>> {
+    return request<T>({method: 'DELETE', endpoint, options})
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,9 +1,9 @@
 import type {
-    GetApiParams,
-    PostApiParams,
-    PatchApiParams,
-    DeleteApiParams,
-    RequestParams,
+    GetApiParameters,
+    PostApiParameters,
+    PatchApiParameters,
+    DeleteApiParameters,
+    RequestParameters,
     ApiResponse,
     ApiPayload,
 } from '@/types/api'
@@ -29,7 +29,7 @@ const response = await del({ endpoint: 'url' })
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL
 
 /** 통합된 HTTP 요청 함수 */
-async function request<T>({method, endpoint, data, options}: RequestParams): Promise<ApiResponse<T>> {
+async function request<T>({method, endpoint, data, options}: RequestParameters): Promise<ApiResponse<T>> {
     const url = `${API_BASE_URL}/${endpoint}`
     const response = await fetch(url, {
         method,
@@ -59,18 +59,18 @@ async function request<T>({method, endpoint, data, options}: RequestParams): Pro
 }
 
 /** HTTP 메서드별 함수 */
-export function get<T>({endpoint, options}: GetApiParams): Promise<ApiResponse<T>> {
+export function get<T>({endpoint, options}: GetApiParameters): Promise<ApiResponse<T>> {
     return request<T>({method: 'GET', endpoint, options})
 }
 
-export function post<T>({endpoint, data, options}: PostApiParams): Promise<ApiResponse<T>> {
+export function post<T>({endpoint, data, options}: PostApiParameters): Promise<ApiResponse<T>> {
     return request<T>({method: 'POST', endpoint, data, options})
 }
 
-export function patch<T>({endpoint, data, options}: PatchApiParams): Promise<ApiResponse<T>> {
+export function patch<T>({endpoint, data, options}: PatchApiParameters): Promise<ApiResponse<T>> {
     return request<T>({method: 'PATCH', endpoint, data, options})
 }
 
-export function del<T>({endpoint, options}: DeleteApiParams): Promise<ApiResponse<T>> {
+export function del<T>({endpoint, options}: DeleteApiParameters): Promise<ApiResponse<T>> {
     return request<T>({method: 'DELETE', endpoint, options})
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,21 +1,23 @@
-// API 응답 인터페이스
-export interface ApiResponse<T = any> {
+export interface ApiResponse<T> {
     data: T
     status: number
     message?: string
 }
 
-// API 에러 인터페이스
 export interface ApiError {
     message: string
     status: number
     code?: string
 }
 
-// HTTP 메서드 타입
+export interface ApiPayload<T> {
+    status: number
+    data?: T
+    message?: string
+}
+
 export type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'DELETE'
 
-// 통합된 request 함수를 위한 매개변수 인터페이스
 export interface RequestParams {
     method: HttpMethod
     endpoint: string
@@ -23,7 +25,6 @@ export interface RequestParams {
     options?: RequestInit
 }
 
-// API 함수 매개변수 인터페이스들
 export interface GetApiParams {
     endpoint: string
     options?: RequestInit

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -18,31 +18,31 @@ export interface ApiPayload<T> {
 
 export type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'DELETE'
 
-export interface RequestParams {
+export interface RequestParameters {
     method: HttpMethod
     endpoint: string
     data?: object
     options?: RequestInit
 }
 
-export interface GetApiParams {
+export interface GetApiParameters {
     endpoint: string
     options?: RequestInit
 }
 
-export interface PostApiParams {
-    endpoint: string
-    data?: object
-    options?: RequestInit
-}
-
-export interface PatchApiParams {
+export interface PostApiParameters {
     endpoint: string
     data?: object
     options?: RequestInit
 }
 
-export interface DeleteApiParams {
+export interface PatchApiParameters {
+    endpoint: string
+    data?: object
+    options?: RequestInit
+}
+
+export interface DeleteApiParameters {
     endpoint: string
     options?: RequestInit
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,47 @@
+// API 응답 인터페이스
+export interface ApiResponse<T = any> {
+    data: T
+    status: number
+    message?: string
+}
+
+// API 에러 인터페이스
+export interface ApiError {
+    message: string
+    status: number
+    code?: string
+}
+
+// HTTP 메서드 타입
+export type HttpMethod = 'GET' | 'POST' | 'PATCH' | 'DELETE'
+
+// 통합된 request 함수를 위한 매개변수 인터페이스
+export interface RequestParams {
+    method: HttpMethod
+    endpoint: string
+    data?: object
+    options?: RequestInit
+}
+
+// API 함수 매개변수 인터페이스들
+export interface GetApiParams {
+    endpoint: string
+    options?: RequestInit
+}
+
+export interface PostApiParams {
+    endpoint: string
+    data?: object
+    options?: RequestInit
+}
+
+export interface PatchApiParams {
+    endpoint: string
+    data?: object
+    options?: RequestInit
+}
+
+export interface DeleteApiParams {
+    endpoint: string
+    options?: RequestInit
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음.

## 📝작업 내용

- 공통으로 쓸 수 있는 api통신 함수 생성했습니다. 사용법은 파일 내 주석 확인 부탁드립니다.
- 에러 핸들링은 통신 결과 확인 후 각 페이지에서 하면 좋을 것 같습니다.


## 💬리뷰 요구사항(선택)

> 데이터 패칭 작업할 때 폴더 내 page.tsx 생성 후 서버컴포넌트에서 데이터 패칭 후 클라이언트컴포넌트 파일 생성하여 데이터를 거기로 넘겨주는 방식이 좋을 것 같은데 어떠신가요 ? 링크 속 예시 봐주시고 자유롭게 의견 남겨주세요
https://www.notion.so/22a4ccb0741c80e08832cc04b6387564?source=copy_link
