### PR TITLE
[Fix] 할일 제거 함수 내 타입 에러 해결

### DIFF
--- a/src/app/todos/page.tsx
+++ b/src/app/todos/page.tsx
@@ -83,7 +83,7 @@ const Page = () => {
         mutationFn: async (todoId: number) => {
             if (!confirm('정말로 이 할 일을 삭제하시겠습니까?')) return
 
-            const response = await del({
+            await del({
                 endpoint: `todos/${todoId}`,
                 options: {
                     headers: {
@@ -91,8 +91,6 @@ const Page = () => {
                     },
                 },
             })
-
-            return response.data
         },
         onSuccess: () => {
             queryClient.invalidateQueries({queryKey: ['todos']})


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#46 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 할일 삭제 함수에서 불필요한 response 변수를 제거하여 타입 에러 해결

수정 전
```tsx
// src/todos/page.tsx 86번 라인
const response = await del({endpoint, options});
return response.data; // response에 data 속성이 없어 오류 발생
```

수정 후
```tsx
await del({endpoint, options}); // response 변수 삭제 (백엔드 API에서 결과값 제공하지 않으므로 삭제해도 무방)

```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
