### PR TITLE
[Fix] 모달을 닫은 뒤 스크롤이 안되는 문제 해결

### DIFF
--- a/src/hooks/use-modal.tsx
+++ b/src/hooks/use-modal.tsx
@@ -196,12 +196,10 @@ export const useModal = <T = unknown,>(
 
     // body 스크롤 제어
     useEffect(() => {
-        const originalOverflow = document.body.style.overflow
-
-        document.body.style.overflow = currentModal ? 'hidden' : originalOverflow
+        document.body.style.overflow = currentModal ? 'hidden' : 'visible'
 
         return () => {
-            document.body.style.overflow = originalOverflow
+            document.body.style.overflow = 'visible'
         }
     }, [currentModal])
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

Closes: #63 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

모달을 닫은 뒤 스크롤이 안되는 문제가 있었습니다.

모달이 열릴 때 <body> 태그에 `overflow: hidden` 속성을 부여해서 스크롤을 막는 방법을 사용했는데,

모달이 해제될 때 overflow 속성이 원래대로 돌아오지 않는 것이 원인이었습니다.

이 부분을 해결했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
