### PR TITLE
[Feature] use-modal tab 버튼막기, focus 주기

### DIFF
--- a/src/hooks/use-modal.tsx
+++ b/src/hooks/use-modal.tsx
@@ -76,6 +76,7 @@ type AnimationProperties = Pick<MotionProps, 'initial' | 'animate' | 'exit' | 't
  * })
  * ```
  */
+
 export const useModal = <T = unknown,>(
     modal: JSX.Element | ((properties: T) => JSX.Element),
     options?: UseModalOptions,
@@ -200,6 +201,67 @@ export const useModal = <T = unknown,>(
 
         return () => {
             document.body.style.overflow = 'visible'
+        }
+    }, [currentModal])
+
+    // 모달 진입 시 tab막기, focus주기
+    useEffect(() => {
+        if (!currentModal || !modalReference.current) return
+
+        const modalElement = modalReference.current
+
+        const focusableElements = [
+            ...modalElement.querySelectorAll<HTMLElement>(
+                'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+            ),
+        ].filter((element) => {
+            // disabled되지 않고, 화면에 보이는 요소만 필터링
+            return (
+                !element.hasAttribute('disabled') &&
+                (!!element.offsetWidth || element.offsetHeight || element.getClientRects().length > 0)
+            )
+        })
+
+        // 모달 진입 시 첫 포커스
+        focusableElements[0]?.focus()
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.key !== 'Tab') return
+
+            const first = focusableElements[0]
+            const last = focusableElements.at(-1)
+
+            if (!first || !last) {
+                // focusable 요소 없으면 Tab 막기
+                event.preventDefault()
+                return
+            }
+
+            if (first === last) {
+                // focusable 요소가 하나라면 tab막고 첫번째 요소에 focus주기
+                event.preventDefault()
+                first.focus()
+                return
+            }
+
+            // tab 이동 순서 제한(focus trap)
+            if (event.shiftKey) {
+                if (document.activeElement === first) {
+                    event.preventDefault()
+                    last.focus()
+                }
+            } else {
+                if (document.activeElement === last) {
+                    event.preventDefault()
+                    first.focus()
+                }
+            }
+        }
+
+        document.addEventListener('keydown', handleKeyDown)
+
+        return () => {
+            document.removeEventListener('keydown', handleKeyDown)
         }
     }, [currentModal])
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

> 기존 use-modal를 오픈하면 tab 버튼 클릭 시 바깥영역으로 focus가 갔지만 focus trap을 주어 tab버튼을 외부로 못나가가게 하고, 초기 focus 를 첫번째 영역으로 주어지게 했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
