### PR TITLE
[Design] 토스트 위치 정가운데로 변경 및 노트 페이지 max-width 설정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -78,6 +78,12 @@ button:disabled {
     ) !important;
 }
 
+.Toastify__toast-container--top-center {
+    top: 50% !important;
+    left: 50% !important;
+    transform: translate(-50%, -50%) !important;
+}
+
 /* note 임시작성 toast custom */
 #noteWrite .Toastify__toast {
     background: transparent !important;

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -77,12 +77,12 @@ const Page = () => {
     hasMore && !isLoading && notes.length > 0 && <div ref={ref} />
 
     return (
-        <div className="bg-slate-100 flex flex-col w-full min-h-screen h-full overflow-y-auto p-6 desktop:px-20 ">
+        <div className="bg-slate-100 flex flex-col w-full min-h-screen h-full overflow-y-auto p-6 desktop:px-20">
             <header>
                 <h1 className="text-subTitle text-custom_slate-900 ">노트 모아보기</h1>
             </header>
 
-            <div className="w-full mt-4 flex-1 flex flex-col">
+            <div className="w-full mt-4 flex-1 flex flex-col max-w-[1200px]">
                 <div className="flex gap-2 items-center bg-white rounded-xl border border-custom_slate-100 py-3.5 px-6">
                     <Image src="/goals/flag-goal.svg" alt="목표깃발" width={28} height={28} />
                     <h2 className="text-subTitle-sm"> {notes.length > 0 ? notes?.[0]?.goal.title : goalData?.title}</h2>

--- a/src/app/providers/toast-provider.tsx
+++ b/src/app/providers/toast-provider.tsx
@@ -4,5 +4,7 @@
 import {ToastContainer} from 'react-toastify'
 
 export default function ToastProvider() {
-    return <ToastContainer position="bottom-center" autoClose={3000} hideProgressBar={false} />
+    return (
+        <ToastContainer position="top-center" toastClassName="center-toast" autoClose={3000} hideProgressBar={false} />
+    )
 }

--- a/src/hooks/use-toast.tsx
+++ b/src/hooks/use-toast.tsx
@@ -24,11 +24,11 @@ interface ShowToastOptions {
  * - `'warning'`: 노란 경고 아이콘과 함께 표시됩니다.
  */
 const showToastImpl = (content: ToastContent, options: ShowToastOptions = {}) => {
-    const {id, type = 'default', position = 'bottom-center'} = options
+    const {id, type = 'default', position = 'top-center'} = options
     const common: ToastOptions = {toastId: id, position}
 
     if (type === 'none') {
-        toast(content, {...common, icon: false})
+        toast(content, {...common, icon: false, className: 'center-toast'})
     } else if (type === 'default') {
         toast(content, common)
     } else {


### PR DESCRIPTION
## #️⃣연관된 이슈

> 없음

## 📝작업 내용

- 토스트가 아래 생성되어 잘 눈에 띄지 않아 정가운데로 위치하게 변경
- 노트 페이지 max-width 설정 (유하님이 만드신 커스텀 스타일을 사용하고 싶었으나 노트 페이지 배경색이 푸른 색이다 보니 사용할 경우 1200만큼만 파랗고 나머지 width는 하얀색이 되어 따로 설정하게 됨

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
