### PR TITLE
[Fix] todo 페이지 스피너 적용 / 사이드 모달 긴 내용 줄바꿈 처리

### DIFF
--- a/src/app/todos/page.tsx
+++ b/src/app/todos/page.tsx
@@ -5,6 +5,7 @@ import {useState} from 'react'
 import {useQueryClient} from '@tanstack/react-query'
 import axios from 'axios'
 
+import LoadingSpinner from '@/components/common/loading-spinner'
 import AddTodoModal from '@/components/common/modal/add-todo-modal'
 import EditTodoModal from '@/components/common/modal/edit-todo-modal'
 import {useCustomMutation} from '@/hooks/use-custom-mutation'
@@ -114,7 +115,9 @@ const Page = () => {
         <div className="flex flex-col w-full bg-slate-100 ">
             <div className="desktop-layout flex flex-col min-h-screen">
                 <div className="flex items-center justify-between ">
-                    <h1 className="text-lg font-semibold">모든 할 일 ({data?.totalCount})</h1>
+                    <h1 className="text-lg font-semibold">
+                        모든 할 일 {data?.totalCount ? `(${data.totalCount})` : ''}
+                    </h1>
                     <button className="text-sm font-semibold text-custom_blue-500" onClick={openAddTodoModal}>
                         + 할 일 추가
                     </button>
@@ -150,9 +153,7 @@ const Page = () => {
                     </div>
 
                     {isLoading ? (
-                        <div className="flex items-center justify-center flex-1 text-sm text-custom_slate-400">
-                            로딩 중...
-                        </div>
+                        <LoadingSpinner />
                     ) : (
                         <>
                             <div className="flex flex-col gap-2 mt-4 overflow-y-auto flex-1 min-h-0">

--- a/src/components/common/modal/side-modal.tsx
+++ b/src/components/common/modal/side-modal.tsx
@@ -72,7 +72,7 @@ const SideModal = ({noteId}: {noteId: number}) => {
                     )}
 
                     <p
-                        className="text-custom_slate-700 prose"
+                        className="text-custom_slate-700 prose break-words"
                         dangerouslySetInnerHTML={{__html: data?.content || ''}}
                     />
                 </>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 모든 할 일 페이지 로딩 스피너 적용
- 사이드 모달 긴 내용 줄바꿈 처리

### 스크린샷 (선택)

#### 모든 할 일 페이지 로딩 스피너 적용
<img width="963" height="783" alt="Screenshot 2025-08-12 at 10 25 05 AM" src="https://github.com/user-attachments/assets/b85035a2-4c4e-4f52-b001-eac771dea4b9" />

#### 사이드 모달 긴 내용 줄바꿈 처리
<img width="777" height="1024" alt="Screenshot 2025-08-12 at 10 24 42 AM" src="https://github.com/user-attachments/assets/536be8e2-5bf5-4ccb-89eb-246abb204a3e" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
